### PR TITLE
use @types instead of typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,12 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@types/lodash": "^4.14.40",
+    "@types/react": "^0.14.50",
+    "@types/react-dom": "^0.14.19",
+    "@types/redux": "^3.6.31",
+    "@types/redux-thunk": "^2.1.31",
+    "@types/sprintf": "0.0.28",
     "copy-webpack-plugin": "^3.0.1",
     "file-loader": "^0.9.0",
     "node-sass": "^3.10.1",

--- a/typings.json
+++ b/typings.json
@@ -1,13 +1,7 @@
 {
   "globalDependencies": {
-    "lodash": "registry:dt/lodash#4.14.0+20160919145112",
-    "react": "registry:dt/react#0.14.0+20160927082313",
-    "react-dom": "registry:dt/react-dom#0.14.0+20160412154040",
-    "redux": "registry:dt/redux#3.5.2+20160703092728",
-    "sprintf": "registry:dt/sprintf#0.0.0+20160316155526"
+    "material-ul": "github:DefinitelyTyped/DefinitelyTyped/material-ui/index.d.ts#240a96b84a1850a89e9d4980945fa6ce23d04c67",
+    "react-tap-event-plugin": "registry:dt/react-tap-event-plugin#0.0.0+20160602142434"
   },
-  "dependencies": {
-    "material-ui": "registry:npm/material-ui#0.15.1+20160817172421",
-    "redux-thunk": "registry:npm/redux-thunk#2.0.0+20160525185520"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
`typings` の代わりに `@types` を利用するように。

`material-ui` が `@types` のものを利用するとエラーになるので `typings` のママ残してます。 #7 